### PR TITLE
feat(auth): use Authorization header for access token; keep refresh in httpOnly cookie

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -22,9 +22,9 @@ export class AuthController {
   @ApiResponse({status: HttpStatus.UNAUTHORIZED, description: 'Неверный email или пароль'})
   @Post('/login')
   async login(@Body() userDto: LoginDto, @Res({ passthrough: true }) res: Response) {
-    const { accessToken, refreshToken, user } = await this.authService.login(userDto)
-    setAuthCookies(res, accessToken, refreshToken)
-    return { user }
+    const { accessToken, refreshToken, user } = await this.authService.login(userDto);
+    setAuthCookies(res, refreshToken);
+    return { tokenType: "Bearer", accessToken, user };
   }
 
   @ApiOperation({summary: 'Регистрация нового аккаунта'})
@@ -33,8 +33,8 @@ export class AuthController {
   @Post('/registration')
   async registration(@Body() userDto: CreateUserDto, @Res({ passthrough: true }) res: Response) {
     const { accessToken, refreshToken, user } = await this.authService.registration(userDto)
-    setAuthCookies(res, accessToken, refreshToken)
-    return { user }
+    setAuthCookies(res, refreshToken)
+    return { tokenType: "Bearer", accessToken, user };
   }
 
   @ApiOperation({summary: 'Обновление токенов'})
@@ -46,8 +46,8 @@ export class AuthController {
     const refreshToken = req.cookies?.[REFRESH_TOKEN_COOKIE];
     const { accessToken, refreshToken: nextRefreshToken, user } = 
       await this.authService.refreshTokens(refreshToken)
-      setAuthCookies(res, accessToken, nextRefreshToken)
-      return { user }
+      setAuthCookies(res, nextRefreshToken)
+      return { tokenType: "Bearer", accessToken, user };
   }
 
   @ApiOperation({ summary: 'Выход (инвалидация refresh + очистка cookie)' })

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -49,35 +49,6 @@ export class AuthService {
     return { ...tokens, user: this.safeUser(user)}
   }
 
-  // async refreshTokens(refreshTokenDto: RefreshTokenDto) {
-  //   const { refreshToken, userId } = refreshTokenDto
-
-  //   const tokenRow = await this.refreshTokenRepository.findOne({
-  //     where: {
-  //       userId,
-  //       expiryDate: {
-  //         [Op.gte]: new Date()
-  //       }
-  //     }
-  //   })
-
-  //   if (!tokenRow) {
-  //     throw new UnauthorizedException('Refresh token is invalid')
-  //   }
-
-  //   const isTokensEqual = await bcrypt.compare(refreshToken, tokenRow.dataValues.token)
-  //   if (!isTokensEqual) {
-  //     throw new UnauthorizedException('Invalid refresh token')
-  //   }
-
-  //   const user = await this.userService.getUserById(tokenRow.dataValues.userId)
-  //   if (!user) {
-  //     throw new HttpException('User not found', HttpStatus.INTERNAL_SERVER_ERROR)
-  //   }
-
-  //   return await this.generateUserTokens(user)
-  // }
-
   async refreshTokens(refreshTokenPlain?: string) {
     if (!refreshTokenPlain) {
       throw new UnauthorizedException('No refresh token')

--- a/src/auth/cookie.const.ts
+++ b/src/auth/cookie.const.ts
@@ -1,22 +1,13 @@
 import { Response } from 'express'
 
-export const ACCESS_TOKEN_COOKIE = 'access_token'
 export const REFRESH_TOKEN_COOKIE = 'refresh_token'
 
 const isProd = process.env.NODE_ENV === 'production'
 
 export const setAuthCookies = (
   res: Response,
-  accessToken: string,
   refreshToken: string,
 ) => {
-  res.cookie(ACCESS_TOKEN_COOKIE, accessToken, {
-    httpOnly: true,
-    secure: isProd,
-    sameSite: 'lax',
-    path: '/',
-    maxAge: 15 * 60 * 1000
-  })
 
   res.cookie(REFRESH_TOKEN_COOKIE, refreshToken, {
     httpOnly: true, 
@@ -28,6 +19,5 @@ export const setAuthCookies = (
 }
 
 export const clearAuthCookies = (res: Response) => {
-  res.clearCookie(ACCESS_TOKEN_COOKIE, {path: '/'})
   res.clearCookie(REFRESH_TOKEN_COOKIE, {path: '/auth'})
 }

--- a/src/common/guards/roles.guard.ts
+++ b/src/common/guards/roles.guard.ts
@@ -1,12 +1,10 @@
-import { CanActivate, ExecutionContext, ForbiddenException, HttpException, HttpStatus, Injectable, UnauthorizedException } from "@nestjs/common";
+import { CanActivate, ExecutionContext, HttpException, HttpStatus, Injectable, UnauthorizedException } from "@nestjs/common";
 import { Reflector } from "@nestjs/core";
 import { JwtService } from "@nestjs/jwt";
 import { Observable } from "rxjs";
 import { ROLES_KEY } from "../decorators/roles-auth.decorator";
 import { User } from "src/users/users.model";
 import { UserPayload } from "../types/user-payload.type";
-import { Request } from "express";
-import { ACCESS_TOKEN_COOKIE } from "src/auth/cookie.const";
 
 @Injectable()
 export class RolesGuard implements CanActivate {
@@ -16,49 +14,30 @@ export class RolesGuard implements CanActivate {
   ) {}
 
   canActivate(context: ExecutionContext): boolean | Promise<boolean> | Observable<boolean> {
-    const requiredRoles = this.reflector.getAllAndOverride<string[]>(ROLES_KEY, [
-      context.getHandler(),
-      context.getClass()
-    ])
-    
-    if (!requiredRoles || requiredRoles.length === 0) {
-      return true
-    }
-
-    const req = context.switchToHttp().getRequest<Request>()
-
-    const token = req.cookies?.[ACCESS_TOKEN_COOKIE];
-
-    if (!token) { 
-      throw new UnauthorizedException('User is unauthorized'); 
-    }
-
-    let payload: UserPayload;
     try {
-      payload = this.jwtService.verify<UserPayload>(token);
-    } catch {
-      throw new UnauthorizedException('Invalid or expired access token');
+      const requiredRoles = this.reflector.getAllAndOverride<string[]>(ROLES_KEY, [
+        context.getHandler(),
+        context.getClass()
+      ])
+      
+      if (!requiredRoles) {
+        return true
+      }
+
+      const req = context.switchToHttp().getRequest()
+      const authHeader = req.headers.authorization
+      const bearer = authHeader.split(' ')[0]
+      const token = authHeader.split(' ')[1]
+      if (bearer !== 'Bearer' || !token) {
+        throw new UnauthorizedException({message: 'User is not authorized'})
+      }
+
+      const payload: UserPayload = this.jwtService.verify(token)
+      req.user = payload.id
+
+      return payload.roles.some(role => requiredRoles.includes(role.value))
+    } catch (e) {
+      throw new HttpException(`No access ${e}`, HttpStatus.FORBIDDEN)
     }
-
-    (req as any).user = payload;
-    (req as any).userId = (payload as any)?.id ?? (payload as any)?.userId;
-
-    const userRoles = normalizeRoles((payload as any).roles);
-    const allowed = userRoles.some((r) => requiredRoles.includes(r));
-    if (!allowed) {
-      throw new ForbiddenException('Insufficient role');
-    }
-
-    return true;
   }
-}
-
-function normalizeRoles(roles: any): string[] {
-  if (!roles) return [];
-  if (Array.isArray(roles) && roles.every((x) => typeof x === 'string')) return roles;
-  if (Array.isArray(roles)) {
-    return roles.map((r) => (typeof r === 'string' ? r : r?.value)).filter(Boolean);
-  }
-  if (roles && typeof roles === 'object' && 'value' in roles) return [roles.value];
-  return [];
 }


### PR DESCRIPTION
Удалён access token из cookies. /auth/login, /auth/registration и /auth/refresh теперь возвращают accessToken в теле ответа; клиент шлёт его в Authorization: Bearer. Refresh token остаётся в httpOnly secure cookie с ротацией. Обновлены cookie-хелперы и JWT-стратегия (извлечение токена из заголовка). Closes #8