### PR TITLE
fix(worker): reset isRunning flag after full scrape

### DIFF
--- a/apps/crypto-data-worker/src/crypto-data-scrapper.service.ts
+++ b/apps/crypto-data-worker/src/crypto-data-scrapper.service.ts
@@ -44,6 +44,8 @@ export class CryptoDataScrapperService {
       await this.collectAllAssets();
     } catch (e) {
       this.log.error(`Cron collect failed: ${e instanceof Error ? e.message : e}`);
+    } finally {
+      this.isRunning = false;
     }
   }
 


### PR DESCRIPTION
Fix worker cron not restarting after scraping 200 assets because the isRunning flag was never reset. Fixes #22.